### PR TITLE
fix filepath variable's scope and fix don't ring sl sound bug

### DIFF
--- a/autoload/sl.vim
+++ b/autoload/sl.vim
@@ -1,3 +1,4 @@
+let s:filepath = expand('<sfile>:h:h') . '/sl.wav'
 let s:data = [
 \  [
 \    [
@@ -79,8 +80,7 @@ function! sl#animate() abort
   setlocal nowrap
   redraw
   if exists('*sound_playfile')
-    let l:filepath = expand('<sfile>:h:h') . '/sl.wav'
-    call sound_playfile(l:filepath)
+    call sound_playfile(s:filepath)
   endif
   while 1
     silent %d _


### PR DESCRIPTION
I found a bug that caused the locomotive to not sound. Perhaps this is due to the scope of the variable that handles the file path. 

Therefore, based on `vim-starwars`'s `let s:dir` variable, changed the file path variable to script local and modified it to be declared outside the function.

Please check this code.

# Provide a minimal init.vim/vimrc

```
set runtimepath+=~/myplugin/vim-sl
```
The filepath behavior when using this plug-in in the home directory is described below.

# Before applying the patch

`echomsg l:filepath`

result = './sl.wav'

# After applying the patch

`echomsg s:filepath`

result = /home/Username/myplugin/vim-sl/sl.wav